### PR TITLE
add headers updater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         {
             "name": "Teclib'",
             "email": "glpi@teclib.com",
-            "homepage": "https://teclib.com"
+            "homepage": "http://teclib-group.com"
         }
     ],
     "support" : {

--- a/src/Tools/Git.php
+++ b/src/Tools/Git.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Glpi\Tools;
+
+class Git {
+
+   private $repoDir;
+
+   public function __construct($repoDir = null) {
+      if ($repoDir === null) {
+         $repoDir = __DIR__;
+      }
+      $this->repoDir = $repoDir;
+   }
+
+   /**
+    * Returns all files tracked in the repository
+    *
+    * @param string $refName a GIT refname (HEAD, a tag, a commit hash, ...)
+    * @throws Exception
+    *
+    * @return array lines outputted by the command
+    */
+   protected function getTrackedFiles($refName = null) {
+      $output = [];
+      if ($refName === null) {
+         $refName = 'HEAD';
+      }
+      try {
+         $output = $this->execute("ls-tree -r '$refName' --name-only");
+      } catch (Exception $e) {
+         throw new Exception("Unable to get tracked files");
+      }
+      return $output;
+   }
+
+   /**
+    * runs a git command
+    *
+    * @param string $command the command to run
+    */
+   protected function execute($command) {
+      $repoDir = $this->repoDir;
+      $command = "git -C '$repoDir' " . $command;
+      exec($command, $output, $retCode);
+      if ($retCode != 0) {
+         throw new Exception('Failed to run git command: $command');
+      }
+      return $output;
+   }
+
+}

--- a/src/Tools/RoboFile.php
+++ b/src/Tools/RoboFile.php
@@ -198,7 +198,11 @@ class RoboFile extends \Robo\Tasks
     */
    public function codeHeadersUpdate() {
       $sourceHeader = $this->getSourceHeader();
-      $git = $this->getGit();
+      $git = $this->getGit(getcwd());
+
+      $template = $git->getFileFromGit('tools/HEADER');
+      $sourceHeader->setHeaderTemplate($template);
+
       $toUpdate = $git->getTrackedFiles();
       foreach ($toUpdate as $file) {
          $sourceHeader->replaceSourceHeader($file);
@@ -211,7 +215,8 @@ class RoboFile extends \Robo\Tasks
     *
     * @return \Glpi\Tools\Git
     */
-   protected function getGit() {
+   protected function getGit($directory) {
+      return new Git($directory);
       return new Git(__DIR__ . '/../../../../../..');
    }
 

--- a/src/Tools/SourceHeader.php
+++ b/src/Tools/SourceHeader.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Glpi\Tools;
+
+class SourceHeader {
+
+   /**
+    * Search for a Header template file in  the projecct first, and failback to internal header template
+    *
+    * @throws Exception
+    *
+    * @return string path to header file
+    */
+   protected function findHeaderTemplateFile() {
+      $filename = __DIR__ . '/../../../../../../tools/HEADER';
+      if (file_exists($filename)) {
+         if (!is_readable($filename)) {
+            throw new Exception("$filename found but is not readable");
+         }
+      } else {
+         $filename = __DIR__ . '/../tools/HEADER';
+      }
+
+      return $filename;
+   }
+
+   /**
+    * Read the header template from a file
+    *
+    * @throws Exception
+    *
+    * @return string header template
+    */
+   protected function getHeaderTemplate() {
+      if (empty($this->headerTemplate)) {
+         $this->headerTemplate = file_get_contents($this->findHeaderTemplateFile());
+         if (empty($this->headerTemplate)) {
+            throw new Exception('Header template file not found');
+         }
+      }
+
+      $copyrightRegex = "#Copyright (\(c\)|©) (\d{4}-)?(\d{4}) #iUm";
+      $year = date("Y");
+      $replacement = 'Copyright © ${2}' . $year . ' ';
+      $this->headerTemplate = preg_replace($copyrightRegex, $replacement, $this->headerTemplate);
+
+      return $this->headerTemplate;
+   }
+
+   /**
+    * Update source code header in a source file
+    *
+    * @param string $filename source code file to process
+    */
+   protected function replaceSourceHeader($filename) {
+      // get the content of the file to update
+      $source = file_get_contents($filename);
+
+      // define regex for the file type
+      $ext = pathinfo($filename, PATHINFO_EXTENSION);
+      switch ($ext) {
+         case 'php':
+            $source = $this->replacesourceHeaderForPHP($source);
+            break;
+
+         default:
+            // Unhandled file format
+            return;
+      }
+
+      if (file_put_contents($filename, $source) === false) {
+         throw new Exception('Failed to write ' . $filename);
+      }
+   }
+
+   /**
+    * Update the header in given source and returns the result
+    *
+    * @param string source code
+    *
+    * @return string updated source code
+    */
+   protected function replacesourceHeaderForPHP($source) {
+      $prefix              = "\<\?php\\n/\*(\*)?\\n";
+      $replacementPrefix   = "<?php\n/**\n";
+      $suffix              = "\\n( )?\*/";
+      $replacementSuffix   = "\n */";
+
+      // format header template for the file type
+      $header = trim($this->getHeaderTemplate());
+      $formatedHeader = $replacementPrefix . $this->getFormatedHeaderTemplate('php', $header) . $replacementSuffix;
+
+      // update authors in formated template
+      $headerMatch = [];
+      $originalAuthors = [];
+      $authors = [];
+      $authorsRegex = "#^.*(\@author .*)$#Um";
+      preg_match('#^' . $prefix . '(.*)' . $suffix . '#Us', $source, $headerMatch);
+      if (isset($headerMatch[0])) {
+         $originalHeader = $headerMatch[0];
+         preg_match_all($authorsRegex, $originalHeader, $originalAuthors);
+         if (isset($originalAuthors[1])) {
+            $originalAuthors = $this->getFormatedHeaderTemplate('php', implode("\n", $originalAuthors[1]));
+            $formatedHeader = preg_replace($authorsRegex, $originalAuthors, $formatedHeader, 1);
+         }
+      }
+
+      // replace the header if it exists
+      $source = preg_replace('#^' . $prefix . '(.*)' . $suffix . '#Us', $formatedHeader, $source, 1);
+      if (empty($source)) {
+         throw new Exception("An error occurred while processing $filename");
+      }
+
+      return $source;
+   }
+
+   /**
+    * Format header template for a file type based on extension
+    *
+    * @param string $extension
+    *
+    * @return string
+    */
+   protected function getFormatedHeaderTemplate($extension, $template) {
+      switch ($extension) {
+         case 'php':
+            $lines = explode("\n", $template);
+            foreach ($lines as &$line) {
+               $line = rtrim(" * $line");
+            }
+            return implode("\n", $lines);
+            break;
+
+         default:
+            return $template;
+      }
+   }
+
+}

--- a/src/Tools/SourceHeader.php
+++ b/src/Tools/SourceHeader.php
@@ -2,7 +2,11 @@
 
 namespace Glpi\Tools;
 
+use \Exception;
+
 class SourceHeader {
+
+   private $headerTemplate = '';
 
    /**
     * Search for a Header template file in  the projecct first, and failback to internal header template
@@ -11,17 +15,25 @@ class SourceHeader {
     *
     * @return string path to header file
     */
+   /*
    protected function findHeaderTemplateFile() {
-      $filename = __DIR__ . '/../../../../../../tools/HEADER';
-      if (file_exists($filename)) {
+      $filename = __DIR__ . '/../../../../../tools/HEADER';
+      $filename = realpath($filename);
+      if ($filename !== false && file_exists($filename)) {
          if (!is_readable($filename)) {
             throw new Exception("$filename found but is not readable");
          }
       } else {
          $filename = __DIR__ . '/../tools/HEADER';
+         $filename = realpath($filename);
       }
 
       return $filename;
+   }
+   */
+
+   public function setHeaderTemplate($template) {
+      $this->headerTemplate = $template;
    }
 
    /**
@@ -52,7 +64,7 @@ class SourceHeader {
     *
     * @param string $filename source code file to process
     */
-   protected function replaceSourceHeader($filename) {
+   public function replaceSourceHeader($filename) {
       // get the content of the file to update
       $source = file_get_contents($filename);
 
@@ -87,7 +99,7 @@ class SourceHeader {
       $replacementSuffix   = "\n */";
 
       // format header template for the file type
-      $header = trim($this->getHeaderTemplate());
+      $header = trim($this->headerTemplate);
       $formatedHeader = $replacementPrefix . $this->getFormatedHeaderTemplate('php', $header) . $replacementSuffix;
 
       // update authors in formated template


### PR DESCRIPTION
add an engine to update headers in PHP files of a project.

How it works:
- enumerates all files tracked in git, and for each file
  - finds the type of file by its extension
  - reads the header template
  - reads the original header
  - modify the header template to match multi line comment style of the filetype
  - updates the year of the copyright
  - retrieve author list from original header
   - puts the authors in the new computed header
   - finally replaces the old header by the new one

worked well on Flyve MDM.

Limited to php files but designed to be updatable for other types (shell for example)

