### PR TITLE
Fix missing test classes in classmap

### DIFF
--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -420,8 +420,6 @@ def prepare(rel_name, archive):
             cwd=build_dir
         )
         p1.communicate()
-        os.remove(os.path.join(build_dir, 'composer.lock'))
-
 
         #cleanup vendors
         for root, dirnames, filenames in os.walk(os.path.join(build_dir, 'vendor')):
@@ -445,6 +443,14 @@ def prepare(rel_name, archive):
             for filename in fnmatch.filter(filenames, 'composer*'):
                 remove_file = os.path.join(build_dir, root, filename)
                 os.remove(remove_file)
+
+        p2 = subprocess.Popen(
+            ['composer', 'dump-autoload', '-o', '--no-dev'],
+            cwd=build_dir
+        )
+        p2.communicate()
+
+        os.remove(os.path.join(build_dir, 'composer.lock'))
 
     compile_mo(build_dir)
 


### PR DESCRIPTION
Cleaned files may be referenced in composer autoloader classmap and can lead to errors like this:
```
[2020-04-06 08:02:16] glpiphplog.WARNING:   *** PHP Warning (2): include(C:\laragon\www\glpi\9.5.git\marketplace\barcode\vendor\composer/../pear/pear/tests/PEAR_Command_Install/bundle/packages/Archive_Tar/Archive/Tar.php): failed to open stream: No such file or directory in C:\laragon\www\glpi\9.5.git\vendor\composer\ClassLoader.php at line 444
  Backtrace :
  vendor\composer\ClassLoader.php:444                include()
  vendor\composer\ClassLoader.php:322                Composer\Autoload\includeFile()
  :                                                  Composer\Autoload\ClassLoader->loadClass()
  :                                                  spl_autoload_call()
  ...rgan\unified-archive\src\UnifiedArchive.php:663 class_exists()
  ...rgan\unified-archive\src\UnifiedArchive.php:117 wapmorgan\UnifiedArchive\UnifiedArchive::checkRequirements()
  inc\marketplace\controller.class.php:91            wapmorgan\UnifiedArchive\UnifiedArchive::canOpenArchive()
  ajax\marketplace.php:44           
```

Dumping autoload after cleaning will prevent this problem.