### PR TITLE
Fix release build when using --commit option

### DIFF
--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -258,14 +258,14 @@ def _do_build(repo, ver):
     else:
         print('Building %s...' % rel_name)
 
+        typestr = 'Tag'
+        typever = ver
+
+        if commit and extra:
+            typestr = 'Commit'
+            typever = commit
+
         if verbose:
-            typestr = 'Tag'
-            typever = ver
-
-            if commit and extra:
-                typestr = 'Commit'
-                typever = commit
-
             print('Release name: %s, %s: %s, Dest: %s' % (
                 rel_name,
                 typestr,

--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -273,8 +273,7 @@ def _do_build(repo, ver):
                 archive
             ))
 
-        ls_files_cmd = 'git ls-tree -r %s --name-only' % ver
-        ls_files = subprocess.check_output(['git', 'ls-tree', '-r', str(ver), '--name-only'])
+        ls_files = subprocess.check_output(['git', 'ls-tree', '-r', str(typever), '--name-only'])
         if sys.version_info[0] == 3:
             ls_files = ls_files.decode()
 


### PR DESCRIPTION
Fix error `subprocess.CalledProcessError: Command '['git', 'ls-tree', '-r', 'my-custom-version', '--name-only']' returned non-zero exit status 128.` returned when calling `vendor/bin/plugin-release --verbose --assume-yes --nogithub --dont-check --release my-custom-version --extra prerelease --commit 5f63f89`

1. `git ls-tree` must use commit if forced by command options.
2. `ls_files_cmd` was not used anymore.