### PR TITLE
Plugin package building Github action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # GLPI tools
 
-A set of tools used in the core GLPI project and aslo from plugins.
+A set of tools used in the core GLPI project and also from plugins.
 
-This provides a bunch of possibilities; see [empty plugin sources](https://github.com/pluginsGLPI/empty) and [empty plugin documentation](http://glpi-plugins.rtfd.io/en/latest/empty/index.html) to know more.
+## Task runner
+
+When required as development dependency using composer, this project provides the `consolidation/robo` task runner.
+This provides a bunch of possibilities; see [empty plugin sources](https://github.com/pluginsGLPI/empty)
+and [empty plugin documentation](http://glpi-plugins.rtfd.io/en/latest/empty/index.html) to know more.
+
+## Github Actions
+
+Following Gihub Actions are available:
+ - [Plugin package building](http://glpi-plugins.rtfd.io/en/latest/empty/index.html).

--- a/github-actions/build-package/Dockerfile
+++ b/github-actions/build-package/Dockerfile
@@ -1,0 +1,6 @@
+FROM ghcr.io/glpi-project/plugin-builder
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/github-actions/build-package/README.md
+++ b/github-actions/build-package/README.md
@@ -1,0 +1,66 @@
+# Build package Github action
+
+This action can be used to build a plugin's release package.
+
+## Usage
+
+### Inputs
+
+ - `plugin-version`: The tag name corresponding to the release.
+
+### Outputs
+
+ - `package-basename`: Basename of the built package.
+ - `package-path`: Path of the built package.
+
+### Example workflow
+
+Following workflow will do these steps each time a tag is pushed:
+ - build the plugin's package;
+ - draft a new release;
+ - attach package to the release.
+
+```yaml
+name: "Plugin release"
+
+on:
+  push:
+    tags:
+       - '*'
+
+jobs:
+  create-release:
+    name: "Create release"
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+      - name: "Build package"
+        id: "build-package"
+        uses: "glpi-project/tools/github-actions/build-package"
+        with:
+          plugin-version: ${{ github.ref }}
+      - name: "Upload package artifact"
+        uses: "actions/upload-artifact@v2"
+        with:
+          name: ${{ steps.build-package.outputs.package-basename }}
+          path: ${{ steps.build-package.outputs.package-path }}
+      - name: "Create release"
+        id: "create-release"
+        uses: "actions/create-release@v1"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+      - name: "Attach package to release"
+        uses: "actions/upload-release-asset@v1"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: ${{ steps.build-package.outputs.package-path }}
+          asset_name: ${{ steps.build-package.outputs.package-basename }}
+          asset_content_type: " application/x-bzip2"
+```

--- a/github-actions/build-package/action.yml
+++ b/github-actions/build-package/action.yml
@@ -1,0 +1,16 @@
+name: "Build package"
+description: "Build a plugin's package"
+inputs:
+  plugin-version:
+    description: "Plugin version to release"
+    required: true
+outputs:
+  package-basename: 
+    description: "Built package basename"
+  package-path: 
+    description: "Built package path"
+runs:
+  using: "docker"
+  image: "Dockerfile"
+  env:
+    PLUGIN_VERSION: ${{ inputs.plugin-version }}

--- a/github-actions/build-package/entrypoint.sh
+++ b/github-actions/build-package/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+composer install --no-progress --no-suggest --no-interaction --prefer-dist
+
+# Check that "plugin-release" script is fetched with project dependencies.
+# TODO Embed the release script in "ghcr.io/glpi-project/plugin-builder" docker image.
+if [ ! -f "vendor/bin/plugin-release" ]
+then
+    echo "Project must have 'glpi-project/tools' in its composer dependencies."
+    exit 1
+fi
+
+# plugin-release requires tags to be fetched.
+# TODO Fix this !
+git fetch --tags
+
+# --assume-yes  Prevent interactions.
+# --dont-check  Do not check if $PLUGIN_VERSION is a valid name for a version.
+# --nogithub    Do not create Github release draft.
+# --nosign      Do not sign package with gpg.
+vendor/bin/plugin-release --assume-yes --dont-check --nogithub --nosign --release $PLUGIN_VERSION --verbose
+
+# Defines output variables.
+echo "::set-output name=package-basename::$(find dist/ -type f -name '*.tar.bz2' | xargs -n 1 basename)"
+echo "::set-output name=package-path::$(find dist/ -type f -name '*.tar.bz2')"

--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -763,6 +763,7 @@ def main():
             #check if specified version exists
             if not is_existing_version(args.release):
                 print_err('%s does not exist!' % args.release)
+                sys.exit(1)
             else:
                 build = True
                 buildver = args.release


### PR DESCRIPTION
This action can be used to build a plugin's release package.

Example of test run that sucessfully created a release and its package: https://github.com/cedric-anne/glpi-plugin-credit/runs/1711133627?check_suite_focus=true