### PR TITLE
Enable usage of Robo 3.x, drop usage of Robo 1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
       "tools/plugin-release"
     ],
     "require": {
-        "consolidation/robo": "^1.3 || ^2.0",
+        "consolidation/robo": "^2.0 || ^3.0",
         "glpi-project/coding-standard": "^0.8",
         "natxet/cssmin": "^3.0",
         "patchwork/jsqueeze": "^1.0",


### PR DESCRIPTION
Robo API has no real BC-breaks, except support of some PHP / symfony versions.

Robo 1.x is for PHP < 7.1, so we can drop it.
Robo 3.x officially supports PHP 8.0, even if I did not find any problem for now on this PHP version.