### PR TITLE
Handle CSSO preserved comments

### DIFF
--- a/src/Tools/LicenceHeadersCheckCommand.php
+++ b/src/Tools/LicenceHeadersCheckCommand.php
@@ -142,6 +142,13 @@ class LicenceHeadersCheckCommand extends Command {
                $header_start_pattern   = '/^(--|#( \/\*\*)?)$/'; // older headers were starting by "# /**"
                $header_content_pattern = '/^(--|#)/'; // older headers were prefixed by "#"
                break;
+            case 'css':
+               $header_line_prefix     = ' * ';
+               $header_prepend_line    = "/*!\n";
+               $header_append_line     = " */\n";
+               $header_start_pattern   = '/^\/\*(\!|\*)?$/'; // older headers were starting by "/**"
+               $header_content_pattern = '/^\s*\*/';
+               break;
             default:
                $header_line_prefix     = ' * ';
                $header_prepend_line    = "/**\n";
@@ -194,7 +201,7 @@ class LicenceHeadersCheckCommand extends Command {
             $header_append_line
          );
 
-         $header_outdated = $updated_header_lines !== $current_header_lines;
+         $header_outdated = array_slice($updated_header_lines, 1, -1) !== array_slice($current_header_lines, 1, -1);
 
          if (!$header_missing && !$header_outdated) {
             continue;


### PR DESCRIPTION
CSSO is one of the most used CSS optimizer. During CSS minification, it only preserves comments starting with `/*!`.

This PR introduces 2 changes :
 - prepended line on CSS files will now be `/*!`;
 - headers content checking will now ignore prepended and appended lines (i.e. lines reserved to comment opening and comment closing), in order to not consider all existing headers as invalid in CSS files.