### PR TITLE
FIx "is not" with literal SyntaxWarning

### DIFF
--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -248,7 +248,7 @@ def _do_build(repo, ver):
             loctxt = ''
             if ascLocal:
                 loctxt = ' locally'
-            if msg is not '':
+            if msg != '':
                 msg += ' and has been %ssigned!' % loctxt
             else:
                 msg += 'Release has been %ssigned!' % loctxt


### PR DESCRIPTION
Fixes SyntaxWarning logged during plugin release.