### PR TITLE
Remove glpi-project/coding-standard dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
       "tools/plugin-release"
     ],
     "require": {
-        "glpi-project/coding-standard": "^0.9",
         "symfony/console": "^4.4 || ^5.0"
     }
 }


### PR DESCRIPTION
We will soon move to PSR-12 in GLPI, and, as we get closer to the standards, having a package defining code rules shared with plugins makes less and less sense. Indeed, some plugins may want to keep old rules, to prevent huge styling changes on codebase, while other may want to use more strict rules than GLPI does. Thus, most of plugins does not even have an automated lint job.

I propose to remove glpi-project/coding-standard dependency from here and let everyone specify its own ruleset. IMHO, it will be easier to maintain, as we will not have to create a `glpi-project/coding-standard` release, then a `glpi-project/tools` release, then a `composer update glpi-project/tools -w` everytime we want to change the ruleset.