### PR TITLE
Fix licence header ending detection

### DIFF
--- a/src/Tools/LicenceHeadersCheckCommand.php
+++ b/src/Tools/LicenceHeadersCheckCommand.php
@@ -151,21 +151,21 @@ class LicenceHeadersCheckCommand extends Command {
                $header_prepend_line    = "/*!\n";
                $header_append_line     = " */\n";
                $header_start_pattern   = '/^\/\*(\!|\*)?$/'; // older headers were starting by "/**" or "/*!"
-               $header_end_pattern     = '/^\s*\*\//';
+               $header_end_pattern     = '/\*\//';
                break;
             case 'twig':
                $header_line_prefix     = ' # ';
                $header_prepend_line    = "{#\n";
                $header_append_line     = " #}\n";
                $header_start_pattern   = '/^\{#$/';
-               $header_end_pattern     = '/^\s*#}/';
+               $header_end_pattern     = '/#}/';
                break;
             default:
                $header_line_prefix     = ' * ';
                $header_prepend_line    = "/**\n";
                $header_append_line     = " */\n";
                $header_start_pattern   = '/^\/\*\*?$/';
-               $header_end_pattern     = '/^\s*\*\//';
+               $header_end_pattern     = '/\*\//';
                break;
          }
 


### PR DESCRIPTION
Sometimes, the last line of licence headers may contains something else than spacing chars, and, in such a case, header ending is not detected, and the whole file content may be considered as current licence header.

For instance, following header ending was not detected:
```php
<?php

/*
 ---------------------
 HEADER....
 --------------------- */
```