### PR TITLE
Handle files with spaces in the name

### DIFF
--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -293,6 +293,7 @@ def _do_build(repo, ver):
                         append = False
                         break
                 if append:
+                    if " " in ls_file: ls_file = "\""+ls_file+"\""
                     paths.append(ls_file)
 
         archive_cmd_pattern = 'git archive --prefix=%s/ %s %s | bzip2 > %s'


### PR DESCRIPTION
Trying to archive a file with a space in the name would cause the archive process to fail.

In the screenshot plugin, the file "Screenshot Plugin Preview.gif" was being interpreted as 3 separate files which didn't exist. The result is an empty archive file with a corrupt empty entry.