### PR TITLE
Fix locales extract from twig templates

### DIFF
--- a/bin/extract-locales
+++ b/bin/extract-locales
@@ -68,7 +68,7 @@ else
     NAME="GLPI"
     EXCLUDE_REGEX="^.\/(\..*|(config|files|lib|marketplace|node_modules|plugins|public|tests|tools|vendor)\/).*"
 fi;
-POTFILE="locales/${NAME,,}.pot"
+POTFILE="$WORKING_DIR/locales/${NAME,,}.pot"
 
 # Clean existing POT file
 if [ ! -d "$WORKING_DIR/locales" ]; then
@@ -78,7 +78,8 @@ fi
 rm -f $POTFILE && touch $POTFILE
 
 # Append locales from PHP
-xgettext `(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.php")` \
+cd $WORKING_DIR
+xgettext `find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.php"` \
     -o $POTFILE \
     -L PHP \
     --add-comments=TRANS \
@@ -95,7 +96,8 @@ xgettext `(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_R
     --keyword=_sn:$F_ARGS_SN
 
 # Append locales from JavaScript
-xgettext `(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.js" -not -name "*.min.js")` \
+cd $WORKING_DIR
+xgettext `find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.js" -not -name "*.min.js"` \
     -o $POTFILE \
     -L JavaScript \
     --add-comments=TRANS \
@@ -115,25 +117,86 @@ xgettext `(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_R
     --keyword=i18n.pgettext:$F_ARGS_X
 
 # Append locales from Twig templates
-for file in $(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.twig")
+
+## Following PHP script convert file content to surround i18n functions call by PHP opening/closing tag
+## (i.e. `__('x')` -> `<?php __('x'); ?>`
+TWIG_TRANSFORM_SCRIPT=$(cat <<'PHP'
+    $content = file_get_contents($argv[1]);
+
+    $offset = 0;
+    $matches = [];
+    do {
+        if (preg_match('/(?<function>__|_n|_x|_nx)\(/', $content, $matches, PREG_OFFSET_CAPTURE, $offset) !== 1) {
+           break;
+        }
+        $content_length  = strlen($content);
+        $function_offset = $matches['function'][1];
+        $function_length = strlen($matches['function'][0]);
+        $opening_parenthesis = 0;
+        $closing_parenthesis = 0;
+        $is_inside_quotes    = false;
+        $quote_char          = null;
+        do {
+            $char = $content[$function_offset + $function_length];
+            if ($char === '\\') {
+                // escape char, ignore next char
+                $function_length++;
+            } elseif ($is_inside_quotes && $quote_char == $char) {
+                $is_inside_quotes = false;
+            } elseif (!$is_inside_quotes && ($char === '\'' || $char === '"')) {
+                $is_inside_quotes = true;
+                $quote_char = $char;
+            } elseif (!$is_inside_quotes && $char === '(') {
+                $opening_parenthesis++;
+            } elseif (!$is_inside_quotes && $char === ')') {
+                $closing_parenthesis++;
+            }
+            $function_length++;
+
+            if ($function_offset + $function_length > $content_length) {
+                break 2; // closing parenthesis not found, probably a syntax issue
+            }
+        } while ($closing_parenthesis < $opening_parenthesis);
+
+        $content_before  = substr($content, 0, $function_offset);
+        $content_altered = '<?php ' . substr($content, $function_offset, $function_length) . '; ?>';
+        $content_after   = substr($content, $function_offset + $function_length);
+        $content         = $content_before . $content_altered . $content_after;
+
+        $offset = $function_offset + strlen($content_altered);
+    } while (true);
+
+    echo $content;
+PHP
+)
+
+## 1. Transform twig files and save them into temp dir
+TEMP_TWIG_DIR=$(mktemp -d -t glpi-locales-XXXXXXXX)
+cd $WORKING_DIR
+for file in $(find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.twig")
 do
-    # 1. Convert file content to replace "{{ function(.*) }}" by "<?php function(.*); ?>" and extract strings via std input
-    # 2. Replace "standard input:line_no" by file location in po file comments
-    contents=`cat $file | sed -r "s|\{\{\s*([a-z0-9_]+\(.*\))\s*\}\}|<?php \1; ?>|gi"`
-    cat $file | perl -0pe "s/\{\{(.*?)\}\}/<?php \1; ?>/gism" | xgettext - \
-        -o $POTFILE \
-        -L PHP \
-        --add-comments=TRANS \
-        --from-code=UTF-8 \
-        --force-po \
-        --join-existing \
-        --sort-output \
-        --keyword=_n:$F_ARGS_N \
-        --keyword=__:$F_ARGS__ \
-        --keyword=_x:$F_ARGS_X \
-        --keyword=_nx:$F_ARGS_NX
-    sed -i -r "s|standard input:([0-9]+)|`echo $file | sed "s|./||"`:\1|g" $POTFILE
+    mkdir -p $(dirname $TEMP_TWIG_DIR/$file)
+    php -r "$TWIG_TRANSFORM_SCRIPT" "$WORKING_DIR/$file" > "$TEMP_TWIG_DIR/$file"
 done
+
+## 2. Extract string from transformed files
+cd $TEMP_TWIG_DIR
+xgettext `find -type f -name "*.twig"` \
+    -o $POTFILE \
+    -L PHP \
+    --add-comments=TRANS \
+    --from-code=UTF-8 \
+    --force-po \
+    --join-existing \
+    --sort-output \
+    --keyword=_n:$F_ARGS_N \
+    --keyword=__:$F_ARGS__ \
+    --keyword=_x:$F_ARGS_X \
+    --keyword=_nx:$F_ARGS_NX
+
+## 3. Clean temporary dir
+cd $WORKING_DIR
+rm -r $TEMP_TWIG_DIR
 
 # Update main language
 LANG=C msginit --no-translator -i $POTFILE -l en_GB -o $WORKING_DIR/locales/en_GB.po


### PR DESCRIPTION
String extract from Twig templates was not working on multiple cases:
 - strings used in `{% %}` blocks were ignored (e.g. `{% set a = __('str') %}`);
 - strings used in `{{ }}` blocks that wre containing complex expressions (e.g. `{{ __('str %s')|format(x) }}`) were ignored.

I tried multiple solutions, and it appears that the more appropriate one was to develop a small replacement script that is able to produce a valid php code that can be parsed by `xgettext`.

Proposed solution has been tested with following cases:
 - `{{ __("str") }}` -> `{{ <?php __("str"); ?> }}`;
 - `{{ __('str') }}` -> `{{ <?php __('str'); ?> }}`;
 - `{{ __('s\'tr') }}` -> `{{ <?php __('s\'tr'); ?> }}`;
 - `{{ __("s\"tr") }}` -> `{{ <?php __("s\"tr"); ?> }}`;
 - `{{ __('str(0)') }}` -> `{{ <?php __('str(0)'); ?> }}`;
 - `{{ _n('str', 'strs', get_plural_number()) }}` -> `{{ <?php _n('str', 'strs', get_plural_number()); ?> }}`;
 - `{{ __('str %s')|format(x) }}` -> `{{ <?php __('str %s'); ?>|format(x) }}`.

I used it on GLPI and many missed strings were found.

Also, the scripts now store modified files in a temporary directory and so strings location is correctly generated, and ``` sed -i -r "s|standard input:([0-9]+)|`echo $file | sed "s|./||"`:\1|g" $POTFILE ``` hack can be removed.