### PR TITLE
Fix locales extract from twig templates

### DIFF
--- a/bin/compile-twig-templates
+++ b/bin/compile-twig-templates
@@ -1,0 +1,13 @@
+#!/usr/bin/env php
+<?php
+require __DIR__.'/../../../autoload.php';
+
+use Glpi\Tools\CompileTwigTemplatesCommand;
+use Symfony\Component\Console\Application;
+
+$command = new CompileTwigTemplatesCommand();
+
+$application = new Application($command->getName());
+$application->add($command);
+$application->setDefaultCommand($command->getName(), true);
+$application->run();

--- a/bin/extract-locales
+++ b/bin/extract-locales
@@ -68,17 +68,49 @@ else
     NAME="GLPI"
     EXCLUDE_REGEX="^.\/(\..*|(config|files|lib|marketplace|node_modules|plugins|public|tests|tools|vendor)\/).*"
 fi;
-POTFILE="locales/${NAME,,}.pot"
+POTFILE="$WORKING_DIR/locales/${NAME,,}.pot"
 
-# Clean existing POT file
 if [ ! -d "$WORKING_DIR/locales" ]; then
     mkdir $WORKING_DIR/locales
 fi
 
+# Clean existing POT file
 rm -f $POTFILE && touch $POTFILE
 
+# Append locales from Twig templates
+# It have to be executed first as the use of `--add-location=file` will remove line numbers
+# from all previous locations, including those which that may be added from PHP/JS files.
+
+if [ -d "$WORKING_DIR/templates" ]; then
+    ## 1. Transform twig files and save them into temp dir
+    TEMP_TWIG_DIR=$(mktemp -d -t glpi-locales-XXXXXXXX)
+    mkdir -p "$TEMP_TWIG_DIR/templates"
+    $SCRIPT_DIR/compile-twig-templates --quiet $WORKING_DIR/templates $TEMP_TWIG_DIR/templates
+
+    ## 2. Extract string from transformed files
+    cd $TEMP_TWIG_DIR
+    xgettext `find -type f -name "*.twig"` \
+        -o $POTFILE \
+        -L PHP \
+        --add-comments=TRANS \
+        --add-location=file \
+        --from-code=UTF-8 \
+        --force-po \
+        --join-existing \
+        --sort-output \
+        --keyword=_n:$F_ARGS_N \
+        --keyword=__:$F_ARGS__ \
+        --keyword=_x:$F_ARGS_X \
+        --keyword=_nx:$F_ARGS_NX
+
+    ## 3. Clean temporary dir
+    cd $SCRIPT_DIR
+    rm -r $TEMP_TWIG_DIR
+fi
+
 # Append locales from PHP
-xgettext `(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.php")` \
+cd $WORKING_DIR
+xgettext `find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.php"` \
     -o $POTFILE \
     -L PHP \
     --add-comments=TRANS \
@@ -95,7 +127,8 @@ xgettext `(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_R
     --keyword=_sn:$F_ARGS_SN
 
 # Append locales from JavaScript
-xgettext `(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.js" -not -name "*.min.js")` \
+cd $WORKING_DIR
+xgettext `find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.js" -not -name "*.min.js"` \
     -o $POTFILE \
     -L JavaScript \
     --add-comments=TRANS \
@@ -113,27 +146,6 @@ xgettext `(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_R
     --keyword=i18n.ngettext:$F_ARGS_N \
     --keyword=i18n.gettext:$F_ARGS__ \
     --keyword=i18n.pgettext:$F_ARGS_X
-
-# Append locales from Twig templates
-for file in $(cd $WORKING_DIR && find -regextype posix-egrep -not -regex $EXCLUDE_REGEX -type f -name "*.twig")
-do
-    # 1. Convert file content to replace "{{ function(.*) }}" by "<?php function(.*); ?>" and extract strings via std input
-    # 2. Replace "standard input:line_no" by file location in po file comments
-    contents=`cat $file | sed -r "s|\{\{\s*([a-z0-9_]+\(.*\))\s*\}\}|<?php \1; ?>|gi"`
-    cat $file | perl -0pe "s/\{\{(.*?)\}\}/<?php \1; ?>/gism" | xgettext - \
-        -o $POTFILE \
-        -L PHP \
-        --add-comments=TRANS \
-        --from-code=UTF-8 \
-        --force-po \
-        --join-existing \
-        --sort-output \
-        --keyword=_n:$F_ARGS_N \
-        --keyword=__:$F_ARGS__ \
-        --keyword=_x:$F_ARGS_X \
-        --keyword=_nx:$F_ARGS_NX
-    sed -i -r "s|standard input:([0-9]+)|`echo $file | sed "s|./||"`:\1|g" $POTFILE
-done
 
 # Update main language
 LANG=C msginit --no-translator -i $POTFILE -l en_GB -o $WORKING_DIR/locales/en_GB.po

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
       "tools/plugin-release"
     ],
     "require": {
-        "symfony/console": "^4.4 || ^5.0"
+        "symfony/console": "^4.4 || ^5.0",
+        "twig/twig": "^3.3"
     }
 }

--- a/src/Tools/CompileTwigTemplatesCommand.php
+++ b/src/Tools/CompileTwigTemplatesCommand.php
@@ -160,6 +160,9 @@ class CompileTwigTemplatesCommand extends Command
 
             public function getFunction(string $name): ?TwigFunction
             {
+                // If not found by parent, return a function that has its own name as callback
+                // so Twig will generate code following this pattern: `$name($parameter, ...)`,
+                // e.g. `__('str')` or `_n('str', 'strs', 5)`.
                 return parent::getFunction($name) ?? new TwigFunction($name, $name);
             }
 

--- a/src/Tools/CompileTwigTemplatesCommand.php
+++ b/src/Tools/CompileTwigTemplatesCommand.php
@@ -1,0 +1,210 @@
+<?php
+/**
+ * ---------------------------------------------------------------------
+ * GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2015-2021 Teclib' and contributors.
+ *
+ * http://glpi-project.org
+ *
+ * based on GLPI - Gestionnaire Libre de Parc Informatique
+ * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI.
+ *
+ * GLPI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * GLPI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * ---------------------------------------------------------------------
+ */
+namespace Glpi\Tools;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Twig\Environment;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+use Twig\TwigTest;
+use Twig\Cache\CacheInterface;
+use Twig\Cache\FilesystemCache;
+use Twig\Loader\FilesystemLoader;
+use Twig\Loader\LoaderInterface;
+use RecursiveDirectoryIterator;
+use RecursiveFilterIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+class CompileTwigTemplatesCommand extends Command
+{
+
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('glpi:tools:compile_twig_templates');
+        $this->setDescription('Compile twig templates into php files.');
+
+        $this->addArgument(
+            'templates-directory',
+            InputArgument::REQUIRED,
+            'Templates directory'
+        );
+
+        $this->addArgument(
+            'output-directory',
+            InputArgument::REQUIRED,
+            'Output directory'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $tpl_dir    = $input->getArgument('templates-directory');
+        $output_dir = $input->getArgument('output-directory');
+
+        $loader = new FilesystemLoader($tpl_dir, dirname($tpl_dir));
+        $twig = $this->getMockedTwigEnvironment($loader);
+        $twig->setCache($this->getTwigCacheHandler($output_dir));
+
+        $files = $this->getTemplatesFiles($tpl_dir);
+
+        $progress_bar = new ProgressBar($output);
+        foreach ($progress_bar->iterate($files) as $file) {
+            $twig->load($file);
+        }
+
+        $output->writeln(''); // New to next line after progress bar display
+
+        return 0; // Success
+    }
+
+    /**
+     * Return template files.
+     *
+     * @param string $directory
+     *
+     * @return array
+     */
+    private function getTemplatesFiles(string $directory): array
+    {
+        $directory = realpath($directory);
+
+        if (!is_dir($directory) || !is_readable($directory)) {
+            throw new \Symfony\Component\Console\Exception\InvalidOptionException(
+                sprintf('Unable to read directory "%s"', $directory)
+            );
+        }
+
+        $dir_iterator = new RecursiveDirectoryIterator($directory);
+
+        $filter_iterator = new class($dir_iterator) extends RecursiveFilterIterator {
+            public function accept(): bool
+            {
+                if ($this->isFile() && !preg_match('/^twig$/', $this->getExtension())) {
+                    return false;
+                }
+                return true;
+            }
+        };
+
+        $recursive_iterator = new RecursiveIteratorIterator(
+            $filter_iterator,
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        $files = [];
+
+        /** @var SplFileInfo $file */
+        foreach ($recursive_iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $files[] = preg_replace(
+                '/^' . preg_quote($directory . DIRECTORY_SEPARATOR, '/') . '/',
+                '',
+                $file->getRealPath()
+            );
+        }
+
+        return $files;
+    }
+
+    /**
+     * Return a mocked Twig environment.
+     * This mocked environment will prevent exceptions to be thrown when custom
+     * functions, filters or tests are used in templates.
+     *
+     * @param LoaderInterface $loader
+     *
+     * @return Environment
+     */
+    private function getMockedTwigEnvironment(LoaderInterface $loader): Environment
+    {
+        return new class ($loader) extends Environment {
+
+            public function getFunction(string $name): ?TwigFunction
+            {
+                return parent::getFunction($name) ?? new TwigFunction($name, $name);
+            }
+
+            public function getFilter(string $name): ?TwigFilter
+            {
+                return parent::getFilter($name) ?? new TwigFilter($name, function () {});
+            }
+
+            public function getTest(string $name): ?TwigTest
+            {
+                if (in_array($name, ['divisible', 'same'])) {
+                    // `same as` and `divisible by` will be search in 2 times.
+                    // First check will be done on first word, should return `null` to
+                    // trigger second search that will be done on full name.
+                    return null;
+                }
+                return parent::getTest($name) ?? new TwigTest($name, function () {});
+            }
+        };
+    }
+
+    /**
+     * Return a custom Twig cache handler.
+     * This handler is usefull to be able to preserve filenames of compiled files.
+     *
+     * @param string $directory
+     *
+     * @return CacheInterface
+     */
+    private function getTwigCacheHandler(string $directory): CacheInterface
+    {
+        return new class($directory) extends FilesystemCache {
+
+            private $directory;
+
+            public function __construct(string $directory, int $options = 0)
+            {
+                $this->directory = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+                parent::__construct($directory, $options);
+            }
+
+            public function generateKey(string $name, string $className): string
+            {
+                return $this->directory . $name;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Alternative to #46 .

All twig templates are compiled into PHP files and saved a temporary directory, then PHP files are processed to extract strings.

Compilation does not require usage of GLPI or any GLPI plugin code, in order to prevent compatibility issues with future GLPI versions.

Logic has been made to preserve filenames in POT file comments, but line numbers cannot be preserved as it is nearly impossible to retrieve line number in source template from compiled line number.

Updated POT file example:
```diff
-#: templates/components/itilobject/fields_panel.html.twig:312
+#: templates/components/itilobject/fields_panel.html.twig
 #: src/NotificationTargetProblem.php:200 src/Problem.php:502
 msgid "Causes"
 msgstr "Causes"

```