### PR TITLE
Prevent unsafe git dir exception

### DIFF
--- a/github-actions/build-package/entrypoint.sh
+++ b/github-actions/build-package/entrypoint.sh
@@ -12,6 +12,7 @@ fi
 
 # plugin-release requires tags to be fetched.
 # TODO Fix this !
+git config --global --add safe.directory $(pwd)
 git fetch --tags
 
 # --assume-yes  Prevent interactions.


### PR DESCRIPTION
Since latest version of git, the `build-package` action is broken. Indeed, UID used in different actions is not always identical, and it triggers git errors.

I guess we can consider the current directory as safe, as we will only use git on it to fetch/list tags.

```
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
Traceback (most recent call last):
  File "/github/workspace/vendor/glpi-project/tools/tools/plugin-release", line 754, in <module>
Namespace(release='2.10.2', nogithub=False, check_only=False, dont_check=True, propose=False, commit=None, extra=None, compile_mo=False, nosign=False, assume_yes=True, verbose=True, f=False)
Building glpi-datainjection-2.10.2...
Release name: glpi-datainjection-2.10.2, Tag: 2.10.2, Dest: /github/workspace/dist/glpi-datainjection-2.10.2.tar.bz2
    main()
  File "/github/workspace/vendor/glpi-project/tools/tools/plugin-release", line 751, in main
    _do_build(repo, buildver)
  File "/github/workspace/vendor/glpi-project/tools/tools/plugin-release", line 276, in _do_build
    ls_files = subprocess.check_output(['git', 'ls-tree', '-r', str(typever), '--name-only'])
  File "/usr/lib/python3.9/subprocess.py", line [42](https://github.com/pluginsGLPI/datainjection/runs/6079832606?check_suite_focus=true#step:5:42)4, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'ls-tree', '-r', '2.10.2', '--name-only']' returned non-zero exit status 128.
```