### PR TITLE
Add ability to preserve tagged data in licence headers

### DIFF
--- a/src/Tools/LicenceHeadersCheckCommand.php
+++ b/src/Tools/LicenceHeadersCheckCommand.php
@@ -592,7 +592,6 @@ class LicenceHeadersCheckCommand extends Command {
          '\.travis.yml', // Travis config
          '\.tx', // Transifex config
 
-         'lib', // Manually included libs
          'node_modules', // npm imported libs
          'vendor', // composer imported libs
 
@@ -604,6 +603,7 @@ class LicenceHeadersCheckCommand extends Command {
          $excluded_elements = array_merge(
             $excluded_elements,
             [
+                'lib', // Manually included libs
                 'dist', // Plugin archives
             ]
          );
@@ -615,6 +615,7 @@ class LicenceHeadersCheckCommand extends Command {
             [
                'config',
                'css\/lib',
+               'lib\/(?!(bundles|index\.php)).+', // Manually included libs, but do not exclude "bundles" subdir or "index.php"
                'files',
                'marketplace',
                'plugins',

--- a/src/Tools/LicenceHeadersCheckCommand.php
+++ b/src/Tools/LicenceHeadersCheckCommand.php
@@ -383,10 +383,16 @@ class LicenceHeadersCheckCommand extends Command {
             if ($this->exclusion_pattern !== null && preg_match($this->exclusion_pattern, $this->getRealPath())) {
                return false;
             }
-            if ($this->isFile() && !preg_match('/^(css|js|php|pl|scss|sh|sql|twig|ya?ml)$/', $this->getExtension())) {
-               return false;
+            if ($this->isDir()) {
+               return true; // parse subdirectories
             }
-            return true;
+            if (preg_match('/^(css|js|php|pl|scss|sh|sql|twig|ya?ml)$/', $this->getExtension())) {
+               return true; // handled extensions
+            }
+            if (basename($this->getPath()) === 'bin') {
+               return true; // executable
+            }
+            return false;
          }
 
          public function getChildren(): ?RecursiveFilterIterator {

--- a/src/Tools/LicenceHeadersCheckCommand.php
+++ b/src/Tools/LicenceHeadersCheckCommand.php
@@ -265,8 +265,10 @@ class LicenceHeadersCheckCommand extends Command {
             if (!empty($pre_header_lines)) {
                $file_contents .= implode('', $pre_header_lines) . "\n";
             }
-            $file_contents .= implode('', $updated_header_lines) . "\n";
-            $file_contents .= implode('', $post_header_lines);
+            $file_contents .= implode('', $updated_header_lines);
+            if (!empty($post_header_lines)) {
+               $file_contents .= "\n" . implode('', $post_header_lines);
+            }
 
             if (strlen($file_contents) !== file_put_contents($filename, $file_contents)) {
                $output->writeln(


### PR DESCRIPTION
Some files may contains additionnal data in their licence header, for instance, an additionnal copyright.

With this PR, additionnal data defined using tags (e.g. `@copyright 2010-2022 Another team`)  will be preserved, unless `--discard-extra-tags` option is used. Also, presence of this addtionnal data will not result in considering file header as outdated.

There is also 2 fixes for GLPI core:
 - `bin/*` files are now checked,
 - `lib/bundles/*` and `lib/index.php` files are now checked.