### PR TITLE
Fix license headers

### DIFF
--- a/bin/compile-twig-templates
+++ b/bin/compile-twig-templates
@@ -1,5 +1,37 @@
 #!/usr/bin/env php
 <?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI tools
+ *
+ * @copyright 2017-2022 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/glpi-project/tools
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI tools.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 require __DIR__.'/../../../autoload.php';
 
 use Glpi\Tools\CompileTwigTemplatesCommand;

--- a/bin/extract-locales
+++ b/bin/extract-locales
@@ -2,32 +2,32 @@
 
 #
 # ---------------------------------------------------------------------
-# GLPI - Gestionnaire Libre de Parc Informatique
-# Copyright (C) 2015-2021 Teclib' and contributors.
 #
-# http://glpi-project.org
+# GLPI tools
 #
-# based on GLPI - Gestionnaire Libre de Parc Informatique
-# Copyright (C) 2003-2014 by the INDEPNET Development Team.
+# @copyright 2017-2022 Teclib' and contributors.
+# @licence   https://www.gnu.org/licenses/gpl-3.0.html
+# @link      https://github.com/glpi-project/tools
 #
 # ---------------------------------------------------------------------
 #
 # LICENSE
 #
-# This file is part of GLPI.
+# This file is part of GLPI tools.
 #
-# GLPI is free software; you can redistribute it and/or modify
+# This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# GLPI is distributed in the hope that it will be useful,
+# This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
 # ---------------------------------------------------------------------
 #
 

--- a/bin/licence-headers-check
+++ b/bin/licence-headers-check
@@ -1,5 +1,37 @@
 #!/usr/bin/env php
 <?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI tools
+ *
+ * @copyright 2017-2022 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/glpi-project/tools
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI tools.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
 require __DIR__.'/../../../autoload.php';
 
 use Glpi\Tools\LicenceHeadersCheckCommand;

--- a/github-actions/build-package/Dockerfile
+++ b/github-actions/build-package/Dockerfile
@@ -1,3 +1,34 @@
+#
+# ---------------------------------------------------------------------
+#
+# GLPI tools
+#
+# @copyright 2017-2022 Teclib' and contributors.
+# @licence   https://www.gnu.org/licenses/gpl-3.0.html
+# @link      https://github.com/glpi-project/tools
+#
+# ---------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of GLPI tools.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ---------------------------------------------------------------------
+#
+
 FROM ghcr.io/glpi-project/plugin-builder
 
 COPY entrypoint.sh /entrypoint.sh

--- a/github-actions/build-package/action.yml
+++ b/github-actions/build-package/action.yml
@@ -1,3 +1,34 @@
+#
+# ---------------------------------------------------------------------
+#
+# GLPI tools
+#
+# @copyright 2017-2022 Teclib' and contributors.
+# @licence   https://www.gnu.org/licenses/gpl-3.0.html
+# @link      https://github.com/glpi-project/tools
+#
+# ---------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of GLPI tools.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ---------------------------------------------------------------------
+#
+
 name: "Build package"
 description: "Build a plugin's package"
 inputs:

--- a/github-actions/build-package/entrypoint.sh
+++ b/github-actions/build-package/entrypoint.sh
@@ -1,5 +1,36 @@
 #!/bin/sh
 
+#
+# ---------------------------------------------------------------------
+#
+# GLPI tools
+#
+# @copyright 2017-2022 Teclib' and contributors.
+# @licence   https://www.gnu.org/licenses/gpl-3.0.html
+# @link      https://github.com/glpi-project/tools
+#
+# ---------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of GLPI tools.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ---------------------------------------------------------------------
+#
+
 composer install --no-progress --no-suggest --no-interaction --prefer-dist
 
 # Check that "plugin-release" script is fetched with project dependencies.

--- a/src/Tools/CompileTwigTemplatesCommand.php
+++ b/src/Tools/CompileTwigTemplatesCommand.php
@@ -1,34 +1,36 @@
 <?php
+
 /**
  * ---------------------------------------------------------------------
- * GLPI - Gestionnaire Libre de Parc Informatique
- * Copyright (C) 2015-2021 Teclib' and contributors.
  *
- * http://glpi-project.org
+ * GLPI tools
  *
- * based on GLPI - Gestionnaire Libre de Parc Informatique
- * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ * @copyright 2017-2022 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/glpi-project/tools
  *
  * ---------------------------------------------------------------------
  *
  * LICENSE
  *
- * This file is part of GLPI.
+ * This file is part of GLPI tools.
  *
- * GLPI is free software; you can redistribute it and/or modify
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
  * ---------------------------------------------------------------------
  */
+
 namespace Glpi\Tools;
 
 use Symfony\Component\Console\Command\Command;

--- a/src/Tools/LicenceHeadersCheckCommand.php
+++ b/src/Tools/LicenceHeadersCheckCommand.php
@@ -1,32 +1,33 @@
 <?php
+
 /**
  * ---------------------------------------------------------------------
- * GLPI - Gestionnaire Libre de Parc Informatique
- * Copyright (C) 2015-2021 Teclib' and contributors.
  *
- * http://glpi-project.org
+ * GLPI tools
  *
- * based on GLPI - Gestionnaire Libre de Parc Informatique
- * Copyright (C) 2003-2014 by the INDEPNET Development Team.
+ * @copyright 2017-2022 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/glpi-project/tools
  *
  * ---------------------------------------------------------------------
  *
  * LICENSE
  *
- * This file is part of GLPI.
+ * This file is part of GLPI tools.
  *
- * GLPI is free software; you can redistribute it and/or modify
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
+ * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * GLPI is distributed in the hope that it will be useful,
+ * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with GLPI. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
  * ---------------------------------------------------------------------
  */
 

--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -1,5 +1,35 @@
 #!/usr/bin/python
-# Adapted from Galette release script
+#
+# ---------------------------------------------------------------------
+#
+# GLPI tools
+#
+# @copyright 2017-2022 Teclib' and contributors.
+# @copyright 2012-2017 The Galette Team
+# @licence   https://www.gnu.org/licenses/gpl-3.0.html
+# @link      https://github.com/glpi-project/tools
+#
+# ---------------------------------------------------------------------
+#
+# LICENSE
+#
+# This file is part of GLPI tools.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# ---------------------------------------------------------------------
+#
 
 import os, sys, argparse, re, git, subprocess
 import tarfile, shutil, gitdb, time, json, fnmatch


### PR DESCRIPTION
License headers were missing or copy/pasted from GLPI.

I added/fixed them, using the GPLv3+.

For the release script, I added a `@copyright 2012-2017 The Galette Team`.