### PR TITLE
Search for licence header template file in .licence-header

### DIFF
--- a/src/Tools/LicenceHeadersCheckCommand.php
+++ b/src/Tools/LicenceHeadersCheckCommand.php
@@ -85,9 +85,16 @@ class LicenceHeadersCheckCommand extends Command {
          $project_dir
       );
 
-      $header_file = $project_dir !== null
-         ? realpath($project_dir . DIRECTORY_SEPARATOR . 'tools' . DIRECTORY_SEPARATOR . 'HEADER')
-         : null;
+      $header_file = null;
+      if ($project_dir !== null) {
+          $path = implode([$project_dir, '.licence-header'], DIRECTORY_SEPARATOR);
+          $legacy_path = implode([$project_dir, 'tools', 'HEADER'], DIRECTORY_SEPARATOR);
+          if (file_exists($path)) {
+              $header_file = realpath($path);
+          } elseif (file_exists($legacy_path)) {
+              $header_file = realpath($legacy_path);
+          }
+      }
 
       $this->addOption(
          'header-file',


### PR DESCRIPTION
With this PR, licence header template file can be placed in `.licence-header` in root directory of the project. It will permit to easilly keep this file in GLPI archive even after `tools` directory removal. Thus, in most plugins, it will permit to not have a `tools` directory that often contains only this file.