### PR TITLE
Symfony 6.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
       "tools/plugin-release"
     ],
     "require": {
-        "symfony/console": "^4.4 || ^5.0",
+        "symfony/console": "^5.4 || ^6.0",
         "twig/twig": "^3.3"
     }
 }


### PR DESCRIPTION
This is required t be able to upgrade symfony/console to 6.x in GLPI.