### PR TITLE
Exclude all hidden files from licence headers checks

### DIFF
--- a/src/Tools/LicenceHeadersCheckCommand.php
+++ b/src/Tools/LicenceHeadersCheckCommand.php
@@ -704,12 +704,7 @@ class LicenceHeadersCheckCommand extends Command {
     */
    protected function getExclusionPattern(string $directory): ?string {
       $excluded_elements = [
-         '\.dependabot', // Dependabot config
-         '\.git',
-         '\.github', // Github specific files
-         '\.gitlab-ci.yml', // Gitlab config
-         '\.travis.yml', // Travis config
-         '\.tx', // Transifex config
+         '(\.|.*\/\.).+', // Any hidden file/directory
 
          'node_modules', // npm imported libs
          'vendor', // composer imported libs


### PR DESCRIPTION
Hidden files are excluded from release archives and are likely to not contains anything that should be protected by a licence. They usually are config files.

See https://github.com/glpi-project/glpi/pull/14942. We had to add licence headers in `docker-compose.yml` file.