### PR TITLE
Fix licence headers check default project dir

### DIFF
--- a/src/LicenceHeadersCheckCommand.php
+++ b/src/LicenceHeadersCheckCommand.php
@@ -72,7 +72,7 @@ class LicenceHeadersCheckCommand extends Command {
       $this->setName('glpi:tools:licence_headers_check');
       $this->setDescription('Check licence header in code source files.');
 
-      $project_dir = realpath(__DIR__ . str_repeat(DIRECTORY_SEPARATOR . '..', 5));
+      $project_dir = realpath(__DIR__ . str_repeat(DIRECTORY_SEPARATOR . '..', 4));
       if ($project_dir === false || !is_readable($project_dir)) {
          $project_dir = null;
       }


### PR DESCRIPTION
Regression introduced in #68.

Command file was moved from `src/Tools` to `src/`, so default project dir should be 4th parent instead of 5th (```GLPI_ROOT_DIR -> /vendor -> /glpi-project -> /tools -> /src```).

