### PR TITLE
Replace deprecated usage of `::set-output`

### DIFF
--- a/github-actions/build-package/entrypoint.sh
+++ b/github-actions/build-package/entrypoint.sh
@@ -53,5 +53,5 @@ git fetch --tags
 vendor/bin/plugin-release --assume-yes --dont-check --nogithub --nosign --release $PLUGIN_VERSION --verbose
 
 # Defines output variables.
-echo "::set-output name=package-basename::$(find dist/ -type f -name '*.tar.bz2' | xargs -n 1 basename)"
-echo "::set-output name=package-path::$(find dist/ -type f -name '*.tar.bz2')"
+echo "package-basename=$(find dist/ -type f -name '*.tar.bz2' | xargs -n 1 basename)" >> $GITHUB_OUTPUT
+echo "package-path=$(find dist/ -type f -name '*.tar.bz2')" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fixes the following deprecation:
![image](https://github.com/glpi-project/tools/assets/33253653/fda01aae-8c33-4be0-b68e-6c90c62c476a)
