### PR TITLE
Fix copyright unduplicate logic

### DIFF
--- a/src/LicenceHeadersCheckCommand.php
+++ b/src/LicenceHeadersCheckCommand.php
@@ -652,10 +652,19 @@ class LicenceHeadersCheckCommand extends Command {
             continue;
          }
 
+         $before = trim($dates_matches['before'] ?? '');
+         $before_pattern = strlen($before) > 0
+            ? '\s*' . preg_quote($before, '/') . '\s+'
+            : '';
+         $after = trim($dates_matches['after'] ?? '');
+         $after_pattern = strlen($after) > 0
+            ? '\s+' . preg_quote($after, '/') . '\s*'
+            : '';
+
          $similar_pattern = '/^'
-            . preg_quote(trim($dates_matches['before'] ?? ''), '/')
-            . '\s+(?<starting_date>\d{4})(-(?<ending_date>\d{4}))?\s+'
-            . preg_quote(trim($dates_matches['after'] ?? ''), '/')
+            . $before_pattern
+            . '(?<starting_date>\d{4})(-(?<ending_date>\d{4}))?'
+            . $after_pattern
             . '$/';
 
          if (count(preg_grep($similar_pattern, $preserved_values)) > 0) {


### PR DESCRIPTION
The copyright tags unduplicate logic in the licence headers update command was not correctly handling the following case:
 - no text between `@copyright` tag and dates (e.g. `@copyright 2015-2025 Teclib' and contributors.`)
 - no text between dates and the end of `@copyright` tag line (e.g. `@copyright Teclib' and contributors 2015-2025`)

On GLPI, without this fix, it would generate duplicated tag, e.g.
```
 * @copyright 2015-2024 Teclib' and contributors.
 * @copyright 2003-2014 by the INDEPNET Development Team.
 * @copyright 2015-2023 Teclib' and contributors.
```

In https://github.com/glpi-project/glpi/pull/16293, the `--discard-extra-tags` option was used to bypass this, but I figured out later that it has deleted extra tags that I had to put back (see https://github.com/glpi-project/glpi/commit/5a35bef0413344b6bf8c2a2f87f9cbd0368ee2e5).

This issue has not been detected so far because plugins copyright tags have always something before and after dates (e.g. `@copyright Copyright (C) 2018-2024 by Teclib'.` where `before="(C)"` and `after="by Teclib'."`)