### PR TITLE
Fix compatibility with Twig 3.12

### DIFF
--- a/src/CompileTwigTemplatesCommand.php
+++ b/src/CompileTwigTemplatesCommand.php
@@ -162,10 +162,13 @@ class CompileTwigTemplatesCommand extends Command
 
             public function getFunction(string $name): ?TwigFunction
             {
-                // If not found by parent, return a function that has its own name as callback
-                // so Twig will generate code following this pattern: `$name($parameter, ...)`,
-                // e.g. `__('str')` or `_n('str', 'strs', 5)`.
-                return parent::getFunction($name) ?? new TwigFunction($name, $name);
+                if (in_array($name, ['__', '_n', '_x', '_nx'], true)) {
+                    // Return a function that has its own name as callback
+                    // for translation functions, so Twig will generate code following this pattern:
+                    // $name($parameter, ...)`, e.g. `__('str')` or `_n('str', 'strs', 5)`.
+                    return new TwigFunction($name, $name);
+                }
+                return parent::getFunction($name) ?? new TwigFunction($name, function () {});
             }
 
             public function getFilter(string $name): ?TwigFilter


### PR DESCRIPTION
In Twig 3.12+, callables validity are checked. Therefore, we cannot longer use fake callables like `'get_plural_number'` that is not a valid global function.

Fixes the following error:
```
+ vendor/bin/extract-locales
+ tee extract.log

In Environment.php line 556:
                                                                               
  An exception has been thrown during the compilation of a template ("Callbac  
  k for function "get_plural_number" is not callable in the current scope.")   
  in "dropdown_form.html.twig".                                                
                                                                               

In ReflectionCallable.php line 47:
                                                                               
  Callback for function "get_plural_number" is not callable in the current sc  
  ope.                                                                         
                                                                               

In ReflectionCallable.php line 45:
                                                                               
  Failed to create closure from callable: function "get_plural_number" not fo  
  und or invalid function name                                                 
                                                                               

glpi:tools:compile_twig_templates <templates-directory> <output-directory>
```