### PR TITLE
Rules to check migrations (POC)

### DIFF
--- a/src/PHPStan/Rules/ForbidGlobalFunctionsRule.php
+++ b/src/PHPStan/Rules/ForbidGlobalFunctionsRule.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI tools
+ *
+ * @copyright 2017-2023 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/glpi-project/tools
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI tools.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiProject\Tools\PHPStan\Rules;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Global_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+class ForbidGlobalFunctionsRule implements Rule
+{
+    private const FORBIDDEN_GLOBAL_FUNCTIONS = [
+        'getItemTypeForTable',
+        'getForeignKeyFieldForItemType'
+    ];
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $errors = [];
+
+        foreach (self::FORBIDDEN_GLOBAL_FUNCTIONS as $function) {
+            if ($node instanceof Node\Expr\FuncCall && $node->name->toString() === $function) {
+                $errors[] = RuleErrorBuilder::message(sprintf('L\'utilisation de la fonction globale %s() est interdite.', $function))->build();
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/src/PHPStan/Rules/ForbidStaticDbFunctionsRule.php
+++ b/src/PHPStan/Rules/ForbidStaticDbFunctionsRule.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * ---------------------------------------------------------------------
+ *
+ * GLPI tools
+ *
+ * @copyright 2017-2023 Teclib' and contributors.
+ * @licence   https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/glpi-project/tools
+ *
+ * ---------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of GLPI tools.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * ---------------------------------------------------------------------
+ */
+
+namespace GlpiProject\Tools\PHPStan\Rules;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Global_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\FileTypeMapper;
+
+class ForbidStaticDbFunctionsRule implements Rule
+{
+    private const FORBIDDEN_STATIC_METHODS = [
+        'getTable',
+        'getForeignKeyField',
+    ];
+
+    public function getNodeType(): string
+    {
+        return Node\Expr\StaticCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $errors = [];
+
+        foreach (self::FORBIDDEN_STATIC_METHODS as $method) {
+            if ($node instanceof Node\Expr\StaticCall && $node->name->toString() === $method) {
+                $errors[] = RuleErrorBuilder::message(sprintf('L\'utilisation de la méthode %s() est interdite.', $method))->build();
+            }
+        }
+        return $errors;
+    }
+}


### PR DESCRIPTION
While I was fixing a migration file, I've a POC to check migration files, so the implicit rules become explicit.

An exemple phpstan config could be, (important part is the rules includes).


```neon 
# phpstan_migrations.neon.dist

parameters:
    level: 4
    bootstrapFiles:
        - stubs/db_config_classes.php
        - stubs/glpi_constants.php
    paths:
        - install/migrations/update_10.0.x_to_11.0.0/
    dynamicConstantNames:
        - GLPI_AJAX_DASHBOARD
        - GLPI_ALLOW_IFRAME_IN_RICH_TEXT
        - GLPI_CACHE_DIR
        - GLPI_CALDAV_IMPORT_STATE
        - GLPI_CENTRAL_WARNINGS
        - GLPI_CONFIG_DIR
        - GLPI_CRON_DIR
        - GLPI_DISABLE_ONLY_FULL_GROUP_BY_SQL_MODE
        - GLPI_DISALLOWED_UPLOADS_PATTERN
        - GLPI_DOC_DIR
        - GLPI_DOCUMENTATION_ROOT_URL
        - GLPI_ENVIRONMENT_TYPE
        - GLPI_FORCE_MAIL
        - GLPI_GRAPH_DIR
        - GLPI_INSTALL_MODE
        - GLPI_INVENTORY_DIR
        - GLPI_LOCAL_I18N_DIR
        - GLPI_LOCK_DIR
        - GLPI_LOG_DIR
        - GLPI_LOG_LVL
        - GLPI_MARKETPLACE_ALLOW_OVERRIDE
        - GLPI_MARKETPLACE_DIR
        - GLPI_MARKETPLACE_ENABLE
        - GLPI_MARKETPLACE_MANUAL_DOWNLOADS
        - GLPI_MARKETPLACE_PLUGINS_API_URI
        - GLPI_MARKETPLACE_PRERELEASES
        - GLPI_NETWORK_REGISTRATION_API_URL
        - GLPI_NETWORK_MAIL
        - GLPI_NETWORK_SERVICES
        - GLPI_PICTURE_DIR
        - GLPI_PLUGIN_DOC_DIR
        - GLPI_RSS_DIR
        - GLPI_SERVERSIDE_URL_ALLOWLIST
        - GLPI_SESSION_DIR
        - GLPI_STRICT_DEPRECATED
        - GLPI_TELEMETRY_URI
        - GLPI_TEXT_MAXSIZE
        - GLPI_THEMES_DIR
        - GLPI_TMP_DIR
        - GLPI_UPLOAD_DIR
        - GLPI_USER_AGENT_EXTRA_COMMENTS
        - GLPI_VAR_DIR
        - GLPI_WEBHOOK_ALLOW_RESPONSE_SAVING
        - PLUGINS_DIRECTORIES
        - TU_USER
        
rules:
    - GlpiProject\Tools\PHPStan\Rules\ForbidStaticDbFunctionsRule
    - GlpiProject\Tools\PHPStan\Rules\ForbidGlobalFunctionsRule
```
   
`level` may be set higher, that not the purpose of these PR.
Some other files may be needed in bootstrap.
String must be translated in english, that's just a fast POC.

   
        