### PR TITLE
Bypass plugin archive path limitation by using the USTAR tar format

### DIFF
--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -445,6 +445,8 @@ def prepare(rel_name, archive):
     plugin.extractall(path=src_dir)
     plugin.close()
 
+    os.remove(archive)
+
     build_dir = os.path.join(src_dir, plugin_name)
 
     print('Adding vendor libraries')
@@ -521,7 +523,7 @@ def prepare(rel_name, archive):
 
     compile_mo(build_dir)
 
-    plugin = tarfile.open(archive, 'w|bz2')
+    plugin = tarfile.open(archive, 'w|bz2', format=tarfile.USTAR_FORMAT)
 
     for i in os.listdir(src_dir):
         plugin.add(


### PR DESCRIPTION
We had an issue with a plugin that has a vendor file with a path greater than 100 chars. It seems to be a PHP bug, see https://github.com/php/php-src/issues/19311

Python uses the `pax`/`posix` format by default since version 3.8. Switching back to the `ustar` format fixes the issue. The `ustar` format limitations should not be an issue, see https://www.gnu.org/software/tar/manual/html_section/Formats.html