### PR TITLE
Ignore var folder in plugins

### DIFF
--- a/src/LicenceHeadersCheckCommand.php
+++ b/src/LicenceHeadersCheckCommand.php
@@ -728,8 +728,9 @@ class LicenceHeadersCheckCommand extends Command {
          $excluded_elements = array_merge(
             $excluded_elements,
             [
-                'lib', // Manually included libs
+                'lib',  // Manually included libs
                 'dist', // Plugin archives
+                'var',  // Lint cache
             ]
          );
       } else if (file_exists($directory . DIRECTORY_SEPARATOR . 'composer.json')


### PR DESCRIPTION
As discussed with @cedric-anne , I need a folder to store some linter cache (rector, phpstan, phpunit).
I've picked `var` as it is standard for symfony projects to store this kind of temporary files.

Thus, I need the header checks to ignore it.
