### PR TITLE
Fix(Core): Fix ValueError: name is too long

### DIFF
--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -523,7 +523,7 @@ def prepare(rel_name, archive):
 
     compile_mo(build_dir)
 
-    plugin = tarfile.open(archive, 'w|bz2', format=tarfile.PAX_FORMAT)
+    plugin = tarfile.open(archive, 'w|bz2', format=tarfile.GNU_FORMAT)
 
     for i in os.listdir(src_dir):
         plugin.add(

--- a/tools/plugin-release
+++ b/tools/plugin-release
@@ -523,7 +523,7 @@ def prepare(rel_name, archive):
 
     compile_mo(build_dir)
 
-    plugin = tarfile.open(archive, 'w|bz2', format=tarfile.USTAR_FORMAT)
+    plugin = tarfile.open(archive, 'w|bz2', format=tarfile.PAX_FORMAT)
 
     for i in os.listdir(src_dir):
         plugin.add(


### PR DESCRIPTION

**`tarfile` with the USTAR format has a limit on the path length**. In USTAR, the **file name (`name`) is limited to 100 characters**, and the **prefix is limited to 155 characters**. If the full path exceeds this, we get this error:

```
ValueError: name is too long
```

See : https://gitlab.teclib.com/glpi-network/cloudinventory/-/jobs/160443

#### Proposed solution

Use a format that supports longer paths, such as **PAX_FORMAT**:

```python
plugin = tarfile.open(archive, 'w|bz2', format=tarfile.PAX_FORMAT)
```

This format can handle much longer file paths and is generally recommended for modern projects (like Node.js projects with deep folder structures).